### PR TITLE
event-listener options & better handler event type

### DIFF
--- a/packages/event-listener/src/index.ts
+++ b/packages/event-listener/src/index.ts
@@ -6,21 +6,25 @@ import { onMount, onCleanup } from "solid-js";
  * @param eventName - Event name to bind to
  * @param handler - Function handler to trigger
  * @param element - HTML element to bind the event to
+ * @param options - *useCapture* boolean or an object that specifies characteristics about the event listener.
  *
  * @example
  * ```ts
  * createEventListener("mouseDown", () => console.log("Click"), document.getElementById("mybutton"))
  * ```
  */
-const createEventListener = <T extends HTMLElement>(
-  eventName: keyof WindowEventMap,
-  handler: (event: Event) => void,
-  targets: T | Array<T> | Window = window
+const createEventListener = <T extends HTMLElement, E extends keyof WindowEventMap>(
+  eventName: E,
+  handler: (event: WindowEventMap[E]) => void,
+  targets: T | Array<T> | Window = window,
+  options?: boolean | AddEventListenerOptions
 ): readonly [add: (el: T | Window) => void, remove: (el: T | Window) => void] => {
   const add = (target: T | Window): void =>
-    target.addEventListener && target.addEventListener(eventName, handler);
+    target.addEventListener &&
+    target.addEventListener(eventName, handler as EventListenerOrEventListenerObject, options);
   const remove = (target: T | Window): void =>
-    target.removeEventListener && target.removeEventListener(eventName, handler);
+    target.removeEventListener &&
+    target.removeEventListener(eventName, handler as EventListenerOrEventListenerObject, options);
   onMount(() => (Array.isArray(targets) ? targets.forEach(add) : add(targets)));
   onCleanup(() => (Array.isArray(targets) ? targets.forEach(remove) : remove(targets)));
   return [add, remove];


### PR DESCRIPTION
Changed createEventListener types a bit: now when creating an event listener, the handler's event prop will have a correct type.

Before:
![image](https://user-images.githubusercontent.com/24491503/140391734-f415b255-5910-4bc6-a515-bd7d44e859e7.png)


Now:
![image](https://user-images.githubusercontent.com/24491503/140391522-b7c1e8a1-cd67-4e16-8238-67a88fc75a6b.png)

Also added `options` property to createEventListener function, for passing options to addEventListener, like `{passive: false}`.