### PR TITLE
Intersection observer improvements

### DIFF
--- a/packages/intersection-observer/src/index.ts
+++ b/packages/intersection-observer/src/index.ts
@@ -1,41 +1,48 @@
-import { onMount, onCleanup } from "solid-js";
+import { onMount, onCleanup, createSignal, Accessor } from "solid-js";
+
+export interface IntersetionObserverOptions {
+  readonly root?: Element | Document | null;
+  readonly rootMargin?: string;
+  readonly thresholds?: number | number[];
+}
 
 /**
  * Creates a very basic Intersection Observer.
  *
  * @param elements - A list of elements to watch
  * @param onChange - An event handler that returns an array of observer entires
- * @param threshold - Threshold of when to detect above a particular point
- * @param root - Root element used as viewport for checking visibility
- * @param rootMarigin - Root margin around theoot
+ * @param options - IntersectionObserver constructor options:
+ * - `root` — The Element or Document whose bounds are used as the bounding box when testing for intersection.
+ * - `rootMargin` — A string which specifies a set of offsets to add to the root's bounding_box when calculating intersections, effectively shrinking or growing the root for calculation purposes.
+ * - `threshold` — Either a single number or an array of numbers between 0.0 and 1.0, specifying a ratio of intersection area to total bounding box area for the observed target.
  *
  * @example
  * ```ts
- * const [ add, remove, start, stop ] = createIntersectionObserver(els);
+ * const { add, remove, start, stop, observer } = createIntersectionObserver(els);
  * ```
  */
+
 export const createIntersectionObserver = (
-  elements: Array<HTMLElement>,
-  onChange: (entries: Array<IntersectionObserverEntry>) => void,
-  threshold: number = 0,
-  root: Element | null = null,
-  rootMargin: string = "0%"
-): [
-  add: (el: HTMLElement) => void,
-  remove: (el: HTMLElement) => void,
-  start: () => void,
-  stop: () => void,
-  observer: IntersectionObserver
-] => {
+  elements: Element[] | Accessor<Element[]>,
+  onChange: IntersectionObserverCallback,
+  options?: IntersetionObserverOptions
+): {
+  add: (el: Element) => void;
+  remove: (el: Element) => void;
+  start: () => void;
+  stop: () => void;
+  observer: IntersectionObserver;
+} => {
   // If not supported, skip
-  const observer = new IntersectionObserver(onChange, { threshold, root, rootMargin });
+  const observer = new IntersectionObserver(onChange, options);
+  const getElements = typeof elements === "function" ? elements : () => elements;
   const add = (el: Element) => observer.observe(el);
   const remove = (el: Element) => observer.unobserve(el);
-  const start = () => elements.forEach(el => add(el));
+  const start = () => getElements().forEach(el => add(el));
   const stop = () => observer.takeRecords().forEach(entry => remove(entry.target));
   onMount(start);
   onCleanup(stop);
-  return [add, remove, start, stop, observer];
+  return { add, remove, start, stop, observer };
 };
 
 type SetEntry = (
@@ -46,36 +53,29 @@ type SetEntry = (
  * Creates a more advanced viewport observer for complex tracking.
  *
  * @param elements - A list of elements to watch
- * @param threshold - Threshold of when to detect above a particular point
- * @param root - Root element used as viewport for checking visibility
- * @param rootMarigin - Root margin around theoot
+ * @param options - IntersectionObserver constructor options:
+ * - `root` — The Element or Document whose bounds are used as the bounding box when testing for intersection.
+ * - `rootMargin` — A string which specifies a set of offsets to add to the root's bounding_box when calculating intersections, effectively shrinking or growing the root for calculation purposes.
+ * - `threshold` — Either a single number or an array of numbers between 0.0 and 1.0, specifying a ratio of intersection area to total bounding box area for the observed target.
  *
  * @example
  * ```ts
- * const [ add, remove, start, stop ] = createIntersectionObserver(el);
+ * const { add, remove, start, stop } = createViewportObserver(els);
  * ```
  */
 export const createViewportObserver = (
-  elements: Array<HTMLElement> = [],
-  threshold: number = 0,
-  root: HTMLElement | null = null,
-  rootMargin: string = "0%"
-): [
-  addEntry: (el: HTMLElement, setter: SetEntry) => void,
-  removeEntry: (el: HTMLElement) => void,
-  start: () => void,
-  stop: () => void
-] => {
+  elements: Element[] | Accessor<Element[]> = [],
+  options?: IntersetionObserverOptions
+): {
+  add: (el: HTMLElement, setter: SetEntry) => void;
+  remove: (el: HTMLElement) => void;
+  start: () => void;
+  stop: () => void;
+} => {
   const setters = new WeakMap<Element, SetEntry>();
   const onChange = (entries: Array<IntersectionObserverEntry>) =>
     entries.forEach(entry => setters.get(entry.target)!(entry));
-  const [add, remove, start, stop] = createIntersectionObserver(
-    elements,
-    onChange,
-    threshold,
-    root,
-    rootMargin
-  );
+  const { add, remove, start, stop } = createIntersectionObserver(elements, onChange, options);
   const addEntry = (el: HTMLElement, setter: SetEntry): void => {
     add(el);
     setters.set(el, setter);
@@ -85,5 +85,42 @@ export const createViewportObserver = (
     remove(el);
   };
   onMount(start);
-  return [addEntry, removeEntry, start, stop];
+  return { add: addEntry, remove: removeEntry, start, stop };
+};
+
+/**
+ * Creates reactive signal that changes when element's visibility changes
+ *
+ * @param element - An element to watch
+ * @param options - A Primitive and IntersectionObserver constructor options:
+ * - `root` — The Element or Document whose bounds are used as the bounding box when testing for intersection.
+ * - `rootMargin` — A string which specifies a set of offsets to add to the root's bounding_box when calculating intersections, effectively shrinking or growing the root for calculation purposes.
+ * - `threshold` — Either a single number or an array of numbers between 0.0 and 1.0, specifying a ratio of intersection area to total bounding box area for the observed target.
+ * - `initialValue` — Initial value of the signal *(default: false)*
+ * - `once` — If true: the stop function will be called automatically after visibility changes *(default: false)*
+ *
+ * @example
+ * ```ts
+ * let el!: HTMLElement
+ * const [isVisible, { start, stop }] = createVisibilityObserver(() => el, { once: true })
+ * ```
+ */
+export const createVisibilityObserver = (
+  element: Element | Accessor<Element>,
+  options?: IntersetionObserverOptions & {
+    initialValue?: boolean;
+    once?: boolean;
+  }
+): [Accessor<boolean>, { start: () => void; stop: () => void }] => {
+  const [isVisible, setVisible] = createSignal(options?.initialValue || false);
+  const getEl = typeof element === "function" ? element : () => element;
+  const { start, stop } = createIntersectionObserver(
+    () => [getEl()],
+    ([entry]) => {
+      setVisible(entry.isIntersecting);
+      if (options?.once && entry.isIntersecting !== !!options?.initialValue) stop();
+    },
+    options
+  );
+  return [isVisible, { start, stop }];
 };

--- a/packages/intersection-observer/src/index.ts
+++ b/packages/intersection-observer/src/index.ts
@@ -3,7 +3,7 @@ import { onMount, onCleanup, createSignal, Accessor } from "solid-js";
 export interface IntersetionObserverOptions {
   readonly root?: Element | Document | null;
   readonly rootMargin?: string;
-  readonly thresholds?: number | number[];
+  readonly threshold?: number | number[];
 }
 
 /**


### PR DESCRIPTION
some changes to the intersection-observer module to improve usability:

Non-breaking changes: 
- the `elements` argument now also accepts function.
This is so that createIntersectionObserver could be called without wrapping it with onMount when we want to pass in a ref, since onMount is used internally anyway.
- improved onChange callback type
- added a new helper function — createVisibilityObserver — to reduce the amount of code that has to be written just to observe if a single element is on a screen.

Breaking changes:
- combined root, rootMargin & threshold arguments into single `options` object. so that it matches the native IntersectionObserver api.
- changed the return values from being a 4-5 item tuple into an object. I think it's just easier to destructure and use it like that.