### PR TITLE
fix readme & createViewportObserver start

### DIFF
--- a/packages/intersection-observer/README.md
+++ b/packages/intersection-observer/README.md
@@ -21,22 +21,23 @@ yarn add @solid-primitives/intersection-observer
 
 ### createIntersectionObserver
 
-```ts
+```tsx
 // Basic usage:
-const [add, { remove, start, stop }] = createIntersectionObserver(el, entries => {
-  console.log(entry.isIntersecting);
+const [add, { remove, start, stop, instance }] = createIntersectionObserver(els, entries => {
+  entries.forEach(e => console.log(e.isIntersecting));
 });
+add(el)
 
 // Directive usage:
 const [observer] = createIntersectionObserver()
-<div use:observer={(e) => console.log(e.isIntersecting)}></div>
+<div use:observer></div>
 ```
 
 ### createViewportObserver
 
 This primitive comes with a number of flexible options. You can specify a callback at the root with an array of elements or individual callbacks for individual elements.
 
-```ts
+```tsx
 // Basic usage:
 const [add, { remove, start, stop, instance }] = createViewportObserver(els, e => {...});
 add(el, e => console.log(e.isIntersecting))

--- a/packages/intersection-observer/test/index.test.ts
+++ b/packages/intersection-observer/test/index.test.ts
@@ -143,13 +143,22 @@ cio("remove function removes observed element", ({ div }) => {
 
 cio("start function observes initial elements", ({ div, img }) => {
   createRoot(dispose => {
-    const [, { start, instance }] = createIntersectionObserver([div, img], () => {});
+    const [, { start, instance, stop }] = createIntersectionObserver([div, img], () => {});
     start();
 
     assert.is(
       (instance as IntersectionObserver).elements.length,
       2,
       "elements in array were not added to the IntersectionObserver"
+    );
+
+    stop();
+    start();
+
+    assert.is(
+      (instance as IntersectionObserver).elements.length,
+      2,
+      "elements were not added to the IntersectionObserver on restart"
     );
 
     const [, { start: start2, instance: instance2 }] = createIntersectionObserver(
@@ -310,13 +319,22 @@ cvo("remove function removes observed element", ({ div }) => {
 
 cvo("start function observes initial elements", ({ div, img }) => {
   createRoot(dispose => {
-    const [, { start, instance }] = createViewportObserver([div, img], () => {});
+    const [, { start, instance, stop }] = createViewportObserver([div, img], () => {});
     start();
 
     assert.is(
       (instance as IntersectionObserver).elements.length,
       2,
       "elements in array were not added to the IntersectionObserver"
+    );
+
+    stop();
+    start();
+
+    assert.is(
+      (instance as IntersectionObserver).elements.length,
+      2,
+      "elements were not added to the IntersectionObserver on restart"
     );
 
     const [, { start: start2, instance: instance2 }] = createViewportObserver([
@@ -329,6 +347,30 @@ cvo("start function observes initial elements", ({ div, img }) => {
       (instance2 as IntersectionObserver).elements.length,
       2,
       "elements in array of tuples were not added to the IntersectionObserver"
+    );
+
+    const [, { start: start3, instance: instance3 }] = createViewportObserver(
+      () => [div, img],
+      () => {}
+    );
+    start3();
+
+    assert.is(
+      (instance3 as IntersectionObserver).elements.length,
+      2,
+      "elements in array accessor were not added to the IntersectionObserver"
+    );
+
+    const [, { start: start4, instance: instance4 }] = createViewportObserver(() => [
+      [div, () => {}],
+      [img, () => {}]
+    ]);
+    start4();
+
+    assert.is(
+      (instance4 as IntersectionObserver).elements.length,
+      2,
+      "elements in an accessor od array of tuples were not added to the IntersectionObserver"
     );
 
     dispose();


### PR DESCRIPTION
I realized that the `start` function from createViewportObserver wasn't actually doing anything, since the initial array of elements passed to the createIntersectionObserver is empty. So now "restarting" should work similarly to createIntersectionObserver.

Also fixed some issues in the usage section in the readme.