### PR TITLE
add test script to run all tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "install": "lerna bootstrap --concurrency 4",
     "format": "prettier -w \"packages/**/*.{js,ts,json,css,tsx,jsx}\"",
-    "ls": "lerna-script"
+    "ls": "lerna-script",
+    "test": "lerna run test --concurrency 4"
   },
   "devDependencies": {
     "@types/jest": "27.0.1",

--- a/packages/event-listener/src/index.ts
+++ b/packages/event-listener/src/index.ts
@@ -92,6 +92,7 @@ export const createEventListener: CreateEventListenerFn = (target, ...propsArray
         )(propsArray.slice(1) as EventProps);
   const add = (target: EventTarget) => {
     targets.includes(target) || targets.push(target);
+    console.log("#############################################");
     target.addEventListener.apply(target, props());
   };
   const remove = (target: EventTarget) => {

--- a/packages/event-listener/test/index.test.ts
+++ b/packages/event-listener/test/index.test.ts
@@ -7,7 +7,7 @@ describe("createEventListener", () => {
       createRoot(dispose => {
         const target = new EventTarget();
         const testEvent = new Event("test");
-        createEventListener<{ test: Event }>(target, "test", ev => {
+        createEventListener<{ test: Event }, EventTarget>(target, "test", ev => {
           expect(ev).toBe(testEvent);
           dispose();
           resolve();
@@ -22,7 +22,7 @@ describe("createEventListener", () => {
         const target = new EventTarget();
         const testEvent = new Event("test");
         let count = 0;
-        createEventListener<{ test: Event }>(target, "test", () => {
+        createEventListener<{ test: Event }, EventTarget>(target, "test", () => {
           count++;
         });
         target.dispatchEvent(testEvent);
@@ -40,7 +40,7 @@ describe("createEventListener", () => {
         const targets = [new EventTarget(), new EventTarget()];
         const testEvent = new Event("test");
         let count = 0;
-        createEventListener<{ test: Event }>(targets, "test", () => {
+        createEventListener<{ test: Event }, EventTarget[]>(targets, "test", () => {
           count++;
         });
         targets.forEach(target => target.dispatchEvent(testEvent));
@@ -57,7 +57,7 @@ describe("createEventListener", () => {
       createRoot(dispose => {
         const target = document.createElement("div");
         const testEvent = new Event("load");
-        const [props, setProps] = createSignal<EventListenerProps>([
+        const [props, setProps] = createSignal<EventListenerProps<HTMLDivElement>>([
           "load",
           (ev: Event) => expect(ev).toBe(testEvent)
         ]);


### PR DESCRIPTION
This

- adds a script to run all tests in all packages from the root of the repo.
- fixes several type errors.

Tests are not yet passing, there is a runtime error.

To try it, run the following at the root of the repo:

```sh
npm install
npm test
```

You will see tests exit with a runtime error inside the `event-listener` tests.