### PR TITLE
Package Stage Badges

### DIFF
--- a/assets/badges/stage-0.json
+++ b/assets/badges/stage-0.json
@@ -1,0 +1,6 @@
+{
+   "schemaVersion": 1,
+   "label": "STAGE",
+   "message": "0",
+   "color": "#FA233E"
+}

--- a/assets/badges/stage-1.json
+++ b/assets/badges/stage-1.json
@@ -1,0 +1,6 @@
+{
+   "schemaVersion": 1,
+   "label": "STAGE",
+   "message": "1",
+   "color": "#FFA15C"
+}

--- a/assets/badges/stage-2.json
+++ b/assets/badges/stage-2.json
@@ -1,0 +1,6 @@
+{
+   "schemaVersion": 1,
+   "label": "STAGE",
+   "message": "2",
+   "color": "#E9DE47"
+}

--- a/assets/badges/stage-3.json
+++ b/assets/badges/stage-3.json
@@ -1,0 +1,6 @@
+{
+   "schemaVersion": 1,
+   "label": "STAGE",
+   "message": "3",
+   "color": "#12C3A2"
+}

--- a/assets/badges/stage-4.json
+++ b/assets/badges/stage-4.json
@@ -1,0 +1,6 @@
+{
+   "schemaVersion": 1,
+   "label": "STAGE",
+   "message": "4",
+   "color": "#2962FF"
+}

--- a/lerna.js
+++ b/lerna.js
@@ -1,67 +1,70 @@
-const { loadPackages, iter } = require('lerna-script');
-const fs = require('fs').promises;
-const path = require('path')
+const { loadPackages, iter } = require("lerna-script");
+const fs = require("fs").promises;
+const path = require("path");
 
 // ------------------------------------------------------------
 // Generates a new README with updates primitive details
 // ------------------------------------------------------------
 async function updateReadme(log) {
-  log.info('updateReadme', 'Updating README documentation');
-  const markdownMagic = require('markdown-magic');
-  const tablemark = require('json-to-markdown-table');
-  const githubURL = 'https://github.com/davedbase/solid-primitives/tree/main/packages/';
-  const sizeShield = 'https://img.shields.io/bundlephobia/minzip/';
-  const bundlephobiaURL = 'https://bundlephobia.com/package/';
-  const npmShield = 'https://img.shields.io/npm/v/';
-  const npmURL = 'https://www.npmjs.com/package/';
+  log.info("updateReadme", "Updating README documentation");
+  const markdownMagic = require("markdown-magic");
+  const tablemark = require("json-to-markdown-table");
+  const githubURL = "https://github.com/davedbase/solid-primitives/tree/main/packages/";
+  const sizeShield = "https://img.shields.io/bundlephobia/minzip/";
+  const bundlephobiaURL = "https://bundlephobia.com/package/";
+  const npmShield = "https://img.shields.io/npm/v/";
+  const npmURL = "https://www.npmjs.com/package/";
   let categories = {};
   // Retrieve packages managed by Lerna
-  await iter.forEach(await loadPackages())(
-    async (lernaPackage) => {
-      const pkgData = await fs.readFile(`${lernaPackage.location}/package.json`, 'utf8');
-      const package = JSON.parse(pkgData);
-      if (!package.primitive) {
-        return;
-      }
-      const { name, list, category, stage } = package.primitive;
-      if (name) {
-        let data = {};
-        data.Name = `[${name}](${githubURL}${name})`;
-        // Detect the stage and build size/version only if needed
-        if (data.Stage == 'X' || data.Stage == 0) {
-          data.Size = '';
-          data.NPM = '';
-        } else {
-          data.Size = `[![SIZE](${sizeShield}${lernaPackage.name}?style=for-the-badge)](${bundlephobiaURL}${lernaPackage.name})`;
-          data.NPM = `[![VERSION](${npmShield}${lernaPackage.name}?style=for-the-badge)](${npmURL}${lernaPackage.name})`;
-        }
-        data.Stage = stage ? stage.toString() : '2';
-        data.Primitives = list.join('<br />');
-        // Merge the package into the correct category
-        let cat = category || 'Misc';
-        categories[cat] = Array.isArray(categories[cat]) ?
-          [ ...categories[cat], data ] :
-          [ data ];
-      }
+  await iter.forEach(await loadPackages())(async lernaPackage => {
+    const pkgData = await fs.readFile(`${lernaPackage.location}/package.json`, "utf8");
+    const package = JSON.parse(pkgData);
+    if (!package.primitive) {
+      return;
     }
-  );
-  // Generate and insert collected package data into Markdown
-  return new Promise((resolve) => {
-    markdownMagic(path.join(__dirname, 'README.md'), {
-      transforms: {
-        GENERATE_PRIMITIVES_TABLE: () => {
-          return Object.entries(categories).reduce((md, [category, items]) => {
-            // Some MD jousting to get the table to render nicely
-            // with consistent columns
-            md += `|<br />*${category}*<br /><br />|\n`;
-            md += tablemark(items, [ 'Name', 'Stage', 'Primitives', 'Size', 'NPM' ])
-              .replace('|Name|Stage|Primitives|Size|NPM|\n', '')
-              .replace('|----|----|----|----|----|\n', '');
-            return md;
-          }, '|Name|Stage|Primitives|Size|NPM|\n|----|----|----|----|----|\n');
-        }
+    const { name, list, category, stage } = package.primitive;
+    if (name) {
+      let data = {};
+      data.Name = `[${name}](${githubURL}${name})`;
+      // Detect the stage and build size/version only if needed
+      if (data.Stage == "X" || data.Stage == 0) {
+        data.Size = "";
+        data.NPM = "";
+      } else {
+        data.Size = `[![SIZE](${sizeShield}${lernaPackage.name}?style=for-the-badge&label=)](${bundlephobiaURL}${lernaPackage.name})`;
+        data.NPM = `[![VERSION](${npmShield}${lernaPackage.name}?style=for-the-badge&label=)](${npmURL}${lernaPackage.name})`;
       }
-    }, resolve)
+      // data.Stage = stage ? stage.toString() : "2";
+      data.Stage = `[![STAGE](https://img.shields.io/endpoint?style=for-the-badge&label=&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-${
+        stage ? stage.toString() : "2"
+      }.json)](https://github.com/davedbase/solid-primitives#contribution-process)`;
+      data.Primitives = list.join("<br />");
+      // Merge the package into the correct category
+      let cat = category || "Misc";
+      categories[cat] = Array.isArray(categories[cat]) ? [...categories[cat], data] : [data];
+    }
+  });
+  // Generate and insert collected package data into Markdown
+  return new Promise(resolve => {
+    markdownMagic(
+      path.join(__dirname, "README.md"),
+      {
+        transforms: {
+          GENERATE_PRIMITIVES_TABLE: () => {
+            return Object.entries(categories).reduce((md, [category, items]) => {
+              // Some MD jousting to get the table to render nicely
+              // with consistent columns
+              md += `|<br />*${category}*<br /><br />|\n`;
+              md += tablemark(items, ["Name", "Stage", "Primitives", "Size", "NPM"])
+                .replace("|Name|Stage|Primitives|Size|NPM|\n", "")
+                .replace("|----|----|----|----|----|\n", "");
+              return md;
+            }, "|Name|Stage|Primitives|Size|NPM|\n|----|----|----|----|----|\n");
+          }
+        }
+      },
+      resolve
+    );
   });
 }
 
@@ -69,11 +72,11 @@ async function updateReadme(log) {
 // Create a new primitive folder based on the default template
 // ------------------------------------------------------------
 async function createPrimitive(log) {
-  const shell = require('child_process').execSync;
-  const { join } = require('path');
+  const shell = require("child_process").execSync;
+  const { join } = require("path");
   const packageName = process.argv.pop();
-  const src = join(__dirname, 'template');
-  const dest = join(__dirname, 'packages', packageName);
+  const src = join(__dirname, "template");
+  const dest = join(__dirname, "packages", packageName);
   shell(`mkdir -p ${dest}`);
   shell(`cp -r ${src}/* ${dest}`);
 }

--- a/packages/active-element/README.md
+++ b/packages/active-element/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/active-element?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/active-element)
 [![size](https://img.shields.io/npm/v/@solid-primitives/active-element?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/active-element)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-2.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 - [`createActiveElement`](#createActiveElement) - A reactive `document.activeElement`. Check which element is currently focused.
 - [`createIsElementActive`](#createIsElementActive) - Pass in an element, and see if it's focused.

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -9,6 +9,7 @@ Category: Utilities
 # @solid-primitives/analytics
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a primitive for analytics management.
 

--- a/packages/audio/README.md
+++ b/packages/audio/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/audio?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/audio)
 [![size](https://img.shields.io/npm/v/@solid-primitives/audio?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/audio)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Primitive to manage audio playback in the browser. The primitives are easily composable and extended. To create your own audio element, consider using createAudioPlayer which allows you to supply a player instance that matches the built-in standard Audio API.
 

--- a/packages/clipboard/README.md
+++ b/packages/clipboard/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/clipboard?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/clipboard)
 [![size](https://img.shields.io/npm/v/@solid-primitives/clipboard?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/clipboard)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Primitive to that make reading and writing to single or multiple values to clipboard easy. It also comes with a convenient directive to write to clipboard.
 

--- a/packages/composites/README.md
+++ b/packages/composites/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/composites?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/composites)
 [![size](https://img.shields.io/npm/v/@solid-primitives/composites?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/composites)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-2.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Composable reactive primitives, extending the `createEffect`, `createComputed`, `createMemo` behaviors using composable and reusable **modifiers**.
 

--- a/packages/countdown/README.md
+++ b/packages/countdown/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/countdown?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/countdown)
 [![size](https://img.shields.io/npm/v/@solid-primitives/countdown?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/countdown)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a countdown primitive based on supplied dates and interval.
 

--- a/packages/date-difference/README.md
+++ b/packages/date-difference/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/date-difference?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/date-difference)
 [![size](https://img.shields.io/npm/v/@solid-primitives/date-difference?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/date-difference)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-2.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Two reactive primitives that provide autoupdating, relative date features.
 

--- a/packages/date-difference/package.json
+++ b/packages/date-difference/package.json
@@ -11,7 +11,7 @@
   },
   "primitive": {
     "name": "date-difference",
-    "stage": 0,
+    "stage": 2,
     "list": [
       "createDateNow",
       "createDateDifference"

--- a/packages/debounce/README.md
+++ b/packages/debounce/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/debounce?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/debounce)
 [![size](https://img.shields.io/npm/v/@solid-primitives/debounce?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/debounce)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a helpful debounce function.
 

--- a/packages/devices/README.md
+++ b/packages/devices/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/devices?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/devices)
 [![size](https://img.shields.io/npm/v/@solid-primitives/devices?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/devices)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a primitive to get a list of media devices (microphones, speakers, cameras). There are filtered primitives for convenience reasons.
 

--- a/packages/event-listener/README.md
+++ b/packages/event-listener/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/event-listener?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/event-listener)
 [![size](https://img.shields.io/npm/v/@solid-primitives/event-listener?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/event-listener)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 A helpful event listener primitive that binds window and any element supplied.
 

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/fetch?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/fetch)
 [![size](https://img.shields.io/npm/v/@solid-primitives/fetch?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/fetch)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a primitive to support abortable HTTP requests. If any reactive request options changes, the request is aborted automatically.
 

--- a/packages/fullscreen/README.md
+++ b/packages/fullscreen/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/fullscreen?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/fullscreen)
 [![size](https://img.shields.io/npm/v/@solid-primitives/fullscreen?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/fullscreen)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a primitive wrapper around the Fullscreen API that can either be used as a directive or a primitive.
 

--- a/packages/geolocation/README.md
+++ b/packages/geolocation/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/geolocation?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/geolocation)
 [![size](https://img.shields.io/npm/v/@solid-primitives/geolocation?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/geolocation)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Primitives to query and watch geolocation information from within the browser.
 

--- a/packages/gestures/README.md
+++ b/packages/gestures/README.md
@@ -1,5 +1,7 @@
 # @solid-primitives/gestures
 
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/davedbase/solid-primitives#contribution-process)
+
 Helpful directives to react to user gestures.
 
 `pan` -

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/audio?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/graphql)
 [![size](https://img.shields.io/npm/v/@solid-primitives/graphql?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/graphql)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a reactive GraphQL query client.
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/i18n?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/i18n)
 [![size](https://img.shields.io/npm/v/@solid-primitives/i18n?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/i18n)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a method for internationalization support. This primitive set is largely inspired by [dlv](https://github.com/developit/dlv/blob/master/index.js) and passes all its tests.
 

--- a/packages/intersection-observer/README.md
+++ b/packages/intersection-observer/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/intersection-observer?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/intersection-observer)
 [![size](https://img.shields.io/npm/v/@solid-primitives/intersection-observer?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/intersection-observer)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 A range of IntersectionObserver API utilities great for different types of usecases:
 

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/media?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/media)
 [![size](https://img.shields.io/npm/v/@solid-primitives/media?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/media)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a very simple and straightforward media query monitor.
 

--- a/packages/mouse/README.md
+++ b/packages/mouse/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/mouse?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/mouse)
 [![size](https://img.shields.io/npm/v/@solid-primitives/mouse?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/mouse)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-2.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 A collection of primitives, capturing current mouse cursor position, and helping to deal with common usecases:
 

--- a/packages/mutation-observer/README.md
+++ b/packages/mutation-observer/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/mutation-observer?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/mutation-observer)
 [![size](https://img.shields.io/npm/v/@solid-primitives/mutation-observer?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/mutation-observer)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-2.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Primitive providing the ability to watch for changes made to the DOM tree. A wrapper for Browser's [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) API.
 

--- a/packages/permission/README.md
+++ b/packages/permission/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/permission?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/permission)
 [![size](https://img.shields.io/npm/v/@solid-primitives/permission?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/permission)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a primitive to query user permissions.
 

--- a/packages/props/README.md
+++ b/packages/props/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/props?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/props)
 [![size](https://img.shields.io/npm/v/@solid-primitives/props?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/props)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a primitive to provide props signals for simple component testing
 

--- a/packages/raf/README.md
+++ b/packages/raf/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/raf?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/raf)
 [![size](https://img.shields.io/npm/v/@solid-primitives/raf?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/raf)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a primitive to support requestAnimationFrame.
 

--- a/packages/resize-observer/README.md
+++ b/packages/resize-observer/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/resize-observer?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/resize-observer)
 [![size](https://img.shields.io/npm/v/@solid-primitives/resize-observer?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/resize-observer)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Provides a reactive resize observer wrapper.
 

--- a/packages/script-loader/README.md
+++ b/packages/script-loader/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/script-loader?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/script-loader)
 [![size](https://img.shields.io/npm/v/@solid-primitives/script-loader?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/script-loader)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a primitive to load scripts dynamically, either for external services or jsonp requests
 

--- a/packages/scroll/README.md
+++ b/packages/scroll/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/scroll?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/scroll)
 [![size](https://img.shields.io/npm/v/@solid-primitives/scroll?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/scroll)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Helpful primitives to manage browser scrolling.
 

--- a/packages/share/README.md
+++ b/packages/share/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/share?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/share)
 [![size](https://img.shields.io/npm/v/@solid-primitives/share?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/share)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-2.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Primitives for supporting sharing of resources on social media and beyond.
 

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/storage?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/storage)
 [![size](https://img.shields.io/npm/v/@solid-primitives/storage?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/storage)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a primitive to reactively access both synchronous and asynchronous persistent storage APIs similar to localStorage.
 

--- a/packages/stream/README.md
+++ b/packages/stream/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/stream?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/stream)
 [![size](https://img.shields.io/npm/v/@solid-primitives/stream?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/stream)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates primitives to work with media streams from microphones, cameras or the screen.
 

--- a/packages/throttle/README.md
+++ b/packages/throttle/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/throttle?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/throttle)
 [![size](https://img.shields.io/npm/v/@solid-primitives/throttle?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/throttle)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates a throttled function that invokes at most once per specified time.
 

--- a/packages/timer/README.md
+++ b/packages/timer/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/timer?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/timer)
 [![size](https://img.shields.io/npm/v/@solid-primitives/timer?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/timer)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 A timer wrapper to handle setTimeout and setInterval.
 

--- a/packages/tween/README.md
+++ b/packages/tween/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/tween?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/tween)
 [![size](https://img.shields.io/npm/v/@solid-primitives/tween?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/tween)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Creates an efficient tweening function.
 

--- a/packages/websocket/README.md
+++ b/packages/websocket/README.md
@@ -9,6 +9,7 @@ Category: Network
 # @solid-primitives/websocket
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 Primitive to help establish, maintain and operate a websocket connection.
 

--- a/packages/workers/README.md
+++ b/packages/workers/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/workers?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/workers)
 [![size](https://img.shields.io/npm/v/@solid-primitives/workers?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/workers)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 A set of utility to support using Web Workers and Shared Workers:
 

--- a/template/README.md
+++ b/template/README.md
@@ -3,6 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/template-primitive?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/template-primitive)
 [![size](https://img.shields.io/npm/v/@solid-primitives/template-primitive?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/template-primitive)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-1.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 A sample primitive that is made up for templating with the following options:
 

--- a/template/README.md
+++ b/template/README.md
@@ -1,8 +1,8 @@
 # @solid-primitives/template-primitive
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
-[![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/template-primitive?style=for-the-badge)](https://bundlephobia.com/package/@solid-primitives/template-primitive)
-[![size](https://img.shields.io/npm/v/@solid-primitives/template-primitive?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/template-primitive)
+[![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/template-primitive?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/template-primitive)
+[![version](https://img.shields.io/npm/v/@solid-primitives/template-primitive?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/template-primitive)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-1.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 A sample primitive that is made up for templating with the following options:

--- a/template/README.md
+++ b/template/README.md
@@ -3,7 +3,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/template-primitive?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/template-primitive)
 [![version](https://img.shields.io/npm/v/@solid-primitives/template-primitive?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/template-primitive)
-[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-1.json)](https://github.com/davedbase/solid-primitives#contribution-process)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
 A sample primitive that is made up for templating with the following options:
 


### PR DESCRIPTION
Adds stage badges to package readmes. Also modifies the lerna script, to generate the table with stage badges instead of just numbers.
[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/davedbase/solid-primitives#contribution-process)
[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-1.json)](https://github.com/davedbase/solid-primitives#contribution-process)
[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-2.json)](https://github.com/davedbase/solid-primitives#contribution-process)
[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/davedbase/solid-primitives#contribution-process)
[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fstage-badges%2Fassets%2Fbadges%2Fstage-4.json)](https://github.com/davedbase/solid-primitives#contribution-process)