### PR TITLE
Add missing type to ResizeObserver

### DIFF
--- a/packages/resize-observer/src/index.ts
+++ b/packages/resize-observer/src/index.ts
@@ -1,5 +1,7 @@
 import { createEffect, createSignal, onCleanup } from "solid-js";
 
+type ResizeHandler = (size: { width: number, height: number }, ref: HTMLElement) => void;
+
 /**
  * Create resize observer is a helper primitive for binding resize events.
  *


### PR DESCRIPTION
Noticed the untyped callback when using this primitive.