### PR TITLE
New package: Map

### DIFF
--- a/packages/map/LICENSE
+++ b/packages/map/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Solid Primitives Working Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/map/README.md
+++ b/packages/map/README.md
@@ -5,12 +5,100 @@
 [![version](https://img.shields.io/npm/v/@solid-primitives/map?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/map)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fmain%2Fasmaps%2Fbadges%2Fstage-1.json)](https://github.com/davedbase/solid-primitives#contribution-process)
 
+The reactive versions of `Map` & `WeakMap` built-in data structures.
+
+- **[`ReactiveMap`](#reactivemap-and-reactiveweakmap)** - A reactive `Map`.
+- **[`createMap`](#createMap)** - Function returning an instance of `ReactiveMap`.
+- **[`ReactiveWeakMap`](#reactivemap-and-reactiveweakmap)** - A reactive `WeakMap`.
+- **[`createWeakMap`](#createWeakMap)** - Function returning an instance of `ReactiveWeakMap`.
+
 ## Installation
 
 ```bash
 npm install @solid-primitives/map
 # or
 yarn add @solid-primitives/map
+```
+
+## `ReactiveMap` and `ReactiveWeakMap`
+
+A reactive version of `Map`/`WeakMap` data structure. All the reads _(e.g. `get` or `has`)_ are signals, and all the writes _(e.g. `delete` or `set`)_ will cause updates to appropriate signals.
+
+### How to use it
+
+#### Import
+
+```ts
+import { ReactiveMap } from "@solid-primitives/map";
+// or
+import { ReactiveWeakMap } from "@solid-primitives/map";
+```
+
+#### Basic usage
+
+The usage is almost the same as the original Javascript structures.
+
+```ts
+const userPoints = new ReactiveMap<User, number>();
+// reads can be listened to reactively
+createEffect(() => {
+  userPoints.get(user1); // => T: number | undefined (reactive)
+  userPoints.has(user1); // => T: boolean (reactive)
+  // ReactiveWeakMap won't have .size or any methods that loop over the values
+  userPoints.size; // => T: number (reactive)
+});
+// apply changes
+userPoints.set(user1, 100);
+userPoints.delete(user2);
+userPoints.set(user1, n => n * 10);
+```
+
+#### Constructor arguments
+
+`ReactiveMap`'s and `ReactiveWeakMap`'s constructor takes two optional arguments:
+
+- `initial` - initial entries of the reactive map
+- `equals` - signal equals function, determining if a change should cause an update
+
+```ts
+const map = new ReactiveMap(
+  [
+    ["foo", [1, 2, 3]],
+    ["bar", [3, 4, 5]]
+  ],
+  (a, b) => a === b || (a.length === 0 && a.length === 0)
+);
+```
+
+#### Values are shallowly wrapped
+
+Treat the values of `ReactiveMap` and `ReactiveMap` as individual signals, to cause updates, they have to be set though the `.set()` method, no mutations.
+
+```ts
+const map = new ReactiveMap<string, { age: number }>();
+map.set("John", { age: 34 });
+
+// this won't cause any updates:
+map.get("John").age = 35;
+
+// this will:
+map.set("John", { age: 35 });
+```
+
+### `createMap` and `createWeakMap`
+
+These functions are returning instances of `ReactiveMap`/`ReactiveWeakMap`.
+
+```ts
+import { createMap } from "@solid-primitives/map";
+// or
+import { createWeakMap } from "@solid-primitives/map";
+
+const userPoints = createMap<User, number>();
+userPoints.get(user1);
+userPoints.set(user1, 100);
+userPoints.set(user1, n => n * 10);
+userPoints.delete(user1);
 ```
 
 ## Changelog

--- a/packages/map/README.md
+++ b/packages/map/README.md
@@ -1,0 +1,25 @@
+# @solid-primitives/map
+
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
+[![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/map?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/map)
+[![version](https://img.shields.io/npm/v/@solid-primitives/map?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/map)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdavedbase%2Fsolid-primitives%2Fmain%2Fasmaps%2Fbadges%2Fstage-1.json)](https://github.com/davedbase/solid-primitives#contribution-process)
+
+## Installation
+
+```bash
+npm install @solid-primitives/map
+# or
+yarn add @solid-primitives/map
+```
+
+## Changelog
+
+<details>
+<summary><b>Expand Changelog</b></summary>
+
+0.0.100
+
+Initial release of the package.
+
+</details>

--- a/packages/map/dev/index.html
+++ b/packages/map/dev/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <title>Solid App</title>
+  <style>
+    html {
+      font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+    }
+
+    body {
+      padding: 0;
+      margin: 0;
+    }
+
+    a,
+    button {
+      cursor: pointer;
+    }
+
+    * {
+      margin: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+
+  <script src="./index.tsx" type="module"></script>
+</body>
+
+</html>

--- a/packages/map/dev/index.tsx
+++ b/packages/map/dev/index.tsx
@@ -1,0 +1,50 @@
+import { Component, For, createSignal } from "solid-js";
+import { render } from "solid-js/web";
+import { ReactiveMap } from "../src";
+import "uno.css";
+import { onCleanup } from "solid-js";
+import { createEffect } from "solid-js";
+
+const App: Component = () => {
+  const map = new ReactiveMap<Element, number>();
+
+  const [count, setCount] = createSignal(1);
+  const decrement = () => setCount(p => Math.max(--p, 0));
+  const increment = () => setCount(p => ++p);
+
+  return (
+    <div class="p-24 box-border w-full min-h-screen flex flex-col justify-center items-center space-y-4 bg-gray-800 text-white">
+      <div class="wrapper-h">
+        <button class="btn" onClick={increment}>
+          Add
+        </button>
+        <button class="btn" onClick={decrement}>
+          Remove
+        </button>
+      </div>
+      <div class="wrapper-h">
+        <For each={Array.from({ length: count() })}>
+          {() => {
+            let ref: Element;
+            onCleanup(() => map.delete(ref));
+            createEffect(() => console.log("increment:", map.get(ref)));
+            return (
+              <button
+                class="btn"
+                ref={el => {
+                  (ref = el), map.set(el, 0);
+                }}
+                onClick={() => map.set(ref, map.get(ref) + 1)}
+              >
+                {map.get(ref)}
+              </button>
+            );
+          }}
+        </For>
+      </div>
+      <p>size: {map.size}</p>
+    </div>
+  );
+};
+
+render(() => <App />, document.getElementById("root"));

--- a/packages/map/dev/tsconfig.json
+++ b/packages/map/dev/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "types": [
+      "vite/client"
+    ]
+  }
+}

--- a/packages/map/dev/vite.config.ts
+++ b/packages/map/dev/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vite";
+import solidPlugin from "vite-plugin-solid";
+import Unocss from "unocss/vite";
+
+export default defineConfig({
+  plugins: [
+    solidPlugin(),
+    Unocss({
+      shortcuts: {
+        "center-child": "flex justify-center items-center",
+        caption: "text-sm font-mono leading-tight",
+        btn: "bg-teal-600 border-1 border-teal-500 hover:bg-teal-500 rounded cursor-pointer center-child select-none text-white font-semibold p-4 py-3",
+        "wrapper-h":
+          "p-8 flex justify-center items-center space-x-4 space-y-0 bg-gray-700 rounded-2xl",
+        "wrapper-v": "wrapper-h flex-col space-x-0 space-y-4",
+        node: "p-4 bg-orange-600 rounded"
+      }
+    })
+  ],
+  build: {
+    target: "esnext",
+    polyfillDynamicImport: false
+  }
+});

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@solid-primitives/map",
+  "version": "0.0.100",
+  "description": "The Map & WeakMap data structures as a reactive signals.",
+  "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/davedbase/solid-primitives/tree/main/packages/utils#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/davedbase/solid-primitives.git"
+  },
+  "bugs": {
+    "url": "https://github.com/davedbase/solid-primitives/issues"
+  },
+  "primitive": {
+    "name": "map",
+    "stage": 1,
+    "list": [
+      "createMap",
+      "createWeakMap"
+    ],
+    "category": "Utilities"
+  },
+  "private": false,
+  "sideEffects": false,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "start": "vite serve dev --host",
+    "dev": "yarn start",
+    "build": "tsup",
+    "test": "uvu -r solid-register"
+  },
+  "keywords": [
+    "map",
+    "weakmap",
+    "solid",
+    "primitives"
+  ],
+  "dependencies": {
+    "@solid-primitives/utils": "^0.5.0"
+  },
+  "devDependencies": {
+    "jsdom": "18.1.1",
+    "prettier": "^2.5.1",
+    "solid-register": "0.1.5",
+    "tslib": "^2.3.1",
+    "typescript": "^4.5.5",
+    "tsup": "^5.11.13",
+    "uvu": "^0.5.3",
+    "unocss": "0.27.2",
+    "vite": "2.8.6",
+    "vite-plugin-solid": "2.2.5"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.3.0"
+  }
+}

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -1,0 +1,118 @@
+import { Accessor } from "solid-js";
+import { createTriggerCache } from "@solid-primitives/utils";
+
+export type SignalMap<K, V> = Accessor<[K, V][]> & ReactiveMap<K, V>;
+
+const WHOLE = Symbol("watch_whole");
+
+export class ReactiveMap<K, V> {
+  private map: Map<K, V>;
+  private cache = createTriggerCache<K | typeof WHOLE>();
+
+  constructor(initial?: [K, V][], private equals = (a: V, b: V) => a === b) {
+    this.map = new Map(initial);
+  }
+
+  // reads
+  has(key: K): boolean {
+    this.cache.track(key);
+    return this.map.has(key);
+  }
+  get(key: K): V | undefined {
+    this.cache.track(key);
+    return this.map.get(key);
+  }
+  get size(): number {
+    this.cache.track(WHOLE);
+    return this.map.size;
+  }
+  keys(): IterableIterator<K> {
+    this.cache.track(WHOLE);
+    return this.map.keys();
+  }
+  values(): IterableIterator<V> {
+    this.cache.track(WHOLE);
+    return this.map.values();
+  }
+  entries(): IterableIterator<[K, V]> {
+    this.cache.track(WHOLE);
+    return this.map.entries();
+  }
+  [Symbol.iterator](): IterableIterator<[K, V]> {
+    return this.entries();
+  }
+
+  // writes
+  set(key: K, value: V): boolean {
+    if (this.map.has(key) && this.equals(this.map.get(key)!, value)) return false;
+    this.map.set(key, value);
+    this.cache.dirty(key);
+    this.cache.dirty(WHOLE);
+    return true;
+  }
+  delete(key: K): boolean {
+    const r = this.map.delete(key);
+    if (r) {
+      this.cache.dirty(key);
+      this.cache.dirty(WHOLE);
+    }
+    return r;
+  }
+  clear(): void {
+    if (this.map.size) {
+      this.map.clear();
+      this.cache.dirtyAll();
+    }
+  }
+
+  // callback
+  forEach(cb: (value: V, key: K) => void) {
+    this.map.forEach(cb);
+  }
+}
+
+export class ReactiveWeakMap<K extends object, V> {
+  private map: WeakMap<K, V>;
+  private cache = createTriggerCache<K>();
+
+  constructor(initial?: [K, V][], private equals = (a: V, b: V) => a === b) {
+    this.map = new WeakMap(initial);
+  }
+
+  has(key: K): boolean {
+    this.cache.track(key);
+    return this.map.has(key);
+  }
+  get(key: K): V | undefined {
+    this.cache.track(key);
+    return this.map.get(key);
+  }
+  set(key: K, value: V): boolean {
+    if (this.map.has(key) && this.equals(this.map.get(key)!, value)) return false;
+    this.map.set(key, value);
+    this.cache.dirty(key);
+    return true;
+  }
+  delete(key: K): boolean {
+    const r = this.map.delete(key);
+    if (r) this.cache.dirty(key);
+    return r;
+  }
+}
+
+export function createMap<K, V>(
+  initial?: [K, V][],
+  equals?: (a: V, b: V) => boolean
+): SignalMap<K, V> {
+  const map = new ReactiveMap(initial, equals);
+  return new Proxy(() => [...map], {
+    get: (_, b) => map[b as keyof typeof map]
+  }) as SignalMap<K, V>;
+}
+
+export function createWeakMap<K extends object, V>(
+  initial?: [K, V][],
+  equals?: (a: V, b: V) => boolean
+): ReactiveWeakMap<K, V> {
+  return new ReactiveWeakMap(initial, equals);
+}

--- a/packages/map/test/index.test.ts
+++ b/packages/map/test/index.test.ts
@@ -1,0 +1,69 @@
+import { ReactiveMap, ReactiveWeakMap } from "../src";
+import { createRoot } from "solid-js";
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+
+const testMap = suite("ReactiveMap");
+
+testMap("behaves like a Map", () =>
+  createRoot(dispose => {
+    const obj1 = {};
+    const obj2 = {};
+
+    const map = new ReactiveMap<any, any>([
+      [obj1, 123],
+      [1, "foo"]
+    ]);
+
+    assert.is(map.has(obj1), true);
+    assert.is(map.has(1), true);
+    assert.is(map.has(2), false);
+
+    assert.is(map.get(obj1), 123);
+    assert.is(map.get(1), "foo");
+
+    map.set(obj2, "bar");
+    assert.is(map.get(obj2), "bar");
+    assert.is(map.set(obj1, "change"), true);
+    assert.is(map.get(obj1), "change");
+
+    assert.is(map.delete(obj2), true);
+    assert.is(map.has(obj2), false);
+
+    assert.is(map.size, 2);
+    map.clear();
+    assert.is(map.size, 0);
+
+    dispose();
+  })
+);
+
+testMap.run();
+
+const testWeakMap = suite("ReactiveWeakMap");
+
+testWeakMap("behaves like a Map", () =>
+  createRoot(dispose => {
+    const obj1 = {};
+    const obj2 = {};
+
+    const map = new ReactiveWeakMap<object, any>([[obj1, 123]]);
+
+    assert.is(map.has(obj1), true);
+    assert.is(map.has(obj2), false);
+
+    assert.is(map.get(obj1), 123);
+
+    map.set(obj2, "bar");
+    assert.is(map.get(obj2), "bar");
+    assert.is(map.set(obj1, "change"), true);
+    assert.is(map.get(obj1), "change");
+
+    assert.is(map.delete(obj2), true);
+    assert.is(map.has(obj2), false);
+
+    dispose();
+  })
+);
+
+testWeakMap.run();

--- a/packages/map/test/index.test.ts
+++ b/packages/map/test/index.test.ts
@@ -38,6 +38,22 @@ testMap("behaves like a Map", () =>
   })
 );
 
+testMap("setter can be a function", () =>
+  createRoot(dispose => {
+    const map = new ReactiveMap<string, number>();
+
+    assert.is(map.set("foo", 0), true);
+    assert.is(map.set("foo", 0), false);
+    assert.is(
+      map.set("foo", p => p! + 1),
+      true
+    );
+    assert.is(map.get("foo"), 1);
+
+    dispose();
+  })
+);
+
 testMap.run();
 
 const testWeakMap = suite("ReactiveWeakMap");

--- a/packages/map/tsconfig.json
+++ b/packages/map/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "./src",
+    "./dev",
+    "./test",
+  ],
+  "exclude": [
+    "node_modules",
+    "./dist"
+  ]
+}

--- a/packages/map/tsup.config.ts
+++ b/packages/map/tsup.config.ts
@@ -1,0 +1,2 @@
+import defaultConfig from '../../tsup.config';
+export default defaultConfig;


### PR DESCRIPTION
If there is a [Set](#65) there has to be a Map. The same concepts, the same architecture.
Here is a snippet:
```ts
const userPoints = new ReactiveMap<User, number>();
// reads can be listened to reactively
createEffect(() => {
  userPoints.get(user1); // => T: number | undefined (reactive)
  userPoints.has(user1); // => T: boolean (reactive)
  // ReactiveWeakMap won't have .size or any methods that loop over the values
  userPoints.size; // => T: number (reactive)
});
// apply changes
userPoints.set(user1, 100);
userPoints.delete(user2);
// setter works similarly as signal's
userPoints.set(user1, n => n * 10);

// mutations are NOT tracked:
map.get("John").age = 35;
```
[The readme](https://github.com/davedbase/solid-primitives/tree/map/packages/map#solid-primitivesmap)