### PR TITLE
[RAF] fix: it's running the loops twice 

### DIFF
--- a/packages/raf/src/index.ts
+++ b/packages/raf/src/index.ts
@@ -50,6 +50,7 @@ const createRAF = (
     requestAnimationFrame(loop);
   };
   const start = () => {
+    if (running()) return;
     setRunning(true);
     requestAnimationFrame(loop);
   };


### PR DESCRIPTION
It's running the loops twice when calling manually to `start()` without setting runImmediately to `false`

runImmediately is to true by default. This means that the loop would be running. If you then call `start()` like in the example provided

```js
const [running, start, stop] = createRAF(() => console.log('hi')));
start();
```

Then you will have two loops running, as `start()` doesn't check if the RAF is currently running. The animation will run twice as fast.

disclaimer: I only tested this on the playground provided by manually calling `start()` right after createRAF