### PR TITLE
Fixes #74 ([RAF] allow limiting fps when > 60)

### DIFF
--- a/packages/raf/README.md
+++ b/packages/raf/README.md
@@ -19,14 +19,14 @@ yarn add @solid-primitives/raf
 
 ```ts
 const [running, start, stop] = createRAF(
-  (timeElapsed) => console.log('Time elapsed is', timeElapsed))
+  (timeStamp) => console.log('Time stamp is', timeStamp))
 );
 start();
 ```
 
 ## Warning
 
-To respect clients refresh rate, timeElapsed should be used to calculate how much the animation should progress in a frame, otherwise the animation will run faster on high refresh rate screens. As an example: A screen refreshing at 300fps will run the animations 5x faster than a screen with 60fps if you use other forms of time keeping. See https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
+To respect clients refresh rate, timeStamp should be used to calculate how much the animation should progress in a given frame, otherwise the animation will run faster on high refresh rate screens. As an example: A screen refreshing at 300fps will run the animations 5x faster than a screen with 60fps if you use other forms of time keeping that don't consider this. Please see https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
 
 ## Demo
 
@@ -52,5 +52,14 @@ Updated to Solid 1.3, switched to peerDependencies
 1.0.9
 
 Patched double running and added refresh rate warning (patch by [titoBouzout](https://www.github.com/titoBouzout)).
+
+2.0.9
+
+- allow to limit fps above 60fps
+- default `targetFps` to `Infinity` instead of 60fps
+- remove `runImmediately` as trying to change the default of this value will require you to provide a `targetFps` which may not be clear that should be `Infinity` in case you want to respect clients fps. Screens above 60fps are becoming increasing popular.
+- respect `requestAnimationFrame` signature and give `timeStamp` back to the callback instead of a `deltaTime` (deltaTime could be added back on a future version)
+
+(patch by [titoBouzout](https://www.github.com/titoBouzout)).
 
 </details>

--- a/packages/raf/package.json
+++ b/packages/raf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/raf",
-  "version": "1.0.9",
+  "version": "2.0.9",
   "description": "Primitive that facilitates RAF functionality",
   "author": "David Di Biase <dave.dibiase@gmail.com>",
   "license": "MIT",
@@ -12,14 +12,10 @@
   "primitive": {
     "name": "raf",
     "stage": 3,
-    "list": [
-      "createRAF"
-    ],
+    "list": ["createRAF"],
     "category": "Display & Media"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "private": false,
   "sideEffects": false,
   "type": "module",
@@ -29,13 +25,7 @@
   "scripts": {
     "build": "tsup"
   },
-  "keywords": [
-    "raf",
-    "animation",
-    "requestAnimationFrame",
-    "solid",
-    "primitives"
-  ],
+  "keywords": ["raf", "animation", "requestAnimationFrame", "solid", "primitives"],
   "devDependencies": {
     "@types/jest": "^27.0.0",
     "prettier": "^2.0.5",
@@ -48,8 +38,6 @@
     "solid-js": "^1.3.1"
   },
   "jest": {
-    "setupFiles": [
-      "./test/setup.ts"
-    ]
+    "setupFiles": ["./test/setup.ts"]
   }
 }

--- a/packages/raf/src/server.ts
+++ b/packages/raf/src/server.ts
@@ -1,9 +1,8 @@
 export type FPS = number | Function;
 
 const createRAF = (
-  _callback: (timeElapse: number) => void,
-  _fps: FPS = 60,
-  _runImmediately = true
+  _callback: (timeStamp: number) => void,
+  _targetFps: FPS = Infinity
 ): [running: () => boolean, start: () => void, stop: () => void] => {
   return [
     () => false,


### PR DESCRIPTION
Related to #74

The RAF package https://github.com/davedbase/solid-primitives/tree/main/packages/raf 

Provides a way to run animations slower than 60 fps. When animations are faster or equal to 60fps then it just uses the screen refresh rate and doesn't limit the execution (which could be high above 60  [300 in my case]). See

https://github.com/davedbase/solid-primitives/blob/43d9abed17cd61cda4238957db82eabafe0ea5e9/packages/raf/src/index.ts#L38-L42

After studying this code, I came to the realization there's a reason for the above. It's hard to target a frame rate, and it's harder without consuming resources(this is very important, we will know below).

The problem is the following: 

When you target a frame rate, you expect something to run after some `ms`. If your `targetFrameRate` is `60`, then you expect the next run to be in around or above `16ms`.  This is a problem because if you get `15ms` (values below 16sm are only possible because of a high refresh rate screen), then that won't satisfy you, and you would wait for the next frame, which will be: the delay already applied :`15ms` + your screen refresh rate. In other words, you didn't accept `15ms` as the time to run something, so you should wait for the next frame, which means that you should wait as long as your screen refresh time is. 

To illustrate it, 
![chrome_b1hHQWkBHM](https://user-images.githubusercontent.com/64156/160003222-fd4c9b0e-b93c-4e36-9362-935d4d4be5d2.png) 
Most of the time this value is near zero(if the callback does little to not work at all), We should always keep in mind that the worse case of this value would be your target frame ms -1 + your frame rate. Which explains why do you see on my screenshot values near 300 / 1000 and around `19ms`. Check it yourself looking at the console after pressing start/stop https://codesandbox.io/s/solid-create-raf-forked-h2bk62?file=/src/index.tsx

This is not a problem you can solve, as you can't change the past(if you were late you late!), but you can change the future, for the sake of "targeting a frame rate" See 
```js
    elapsed = timeStamp - lastRun;
    if (elapsed + missedBy >= interval) {
      lastRun = timeStamp;
      missedBy = Math.max(elapsed - interval, 0)
      callback(timeStamp);
    }
```

The `missedBy` accounts for how much time was wasted on the last render, and consider it on the next frame to recover from that to give the best of the experiences.

Here is the tricky part, there are two kinds of users for a `targetFps`:
- you can target a frame rate consistently as desired by consuming all or most of my CPU because that's your requirement (by counting how many frames you painted, etc)
- you can target a frame rate to do exactly the opposite, to clam down the CPU (theres no reason to run something so many times if you consider that less is better)

I am satisfying the latter here, and the former maybe can be satisfied by another package(which Im not even sure its worthy because they will most likely do it themselves)

Un/Related considerations of this pull request:

- The signature of requestAnimationFrame doesn't match what's provided by this, so I made them match. this is no longer providing a delta, it provides what requestAnimationFrame  gives, and if users want the delta we can do it on a future update as a secondary argument
- It changes the `targetFps` default value from `60` to `Infinity`, that way we can target values above 60
- it does some rename from `fps` to `targetFps`, as `fps` doesn't really mirror the current `fps`, it's just a target. I figure we can tell "at how many `fps` we are running and pass it down" as we are already running a RAF non-stop.

Disclaimer, I have no idea how to run this TypeScript, so I only tested by copying pasting on codesandbox, so if you can takes a test 🙏 would be welcome. I would like to try to setup myself to deal with TS but well.
